### PR TITLE
Scaffold production-ready Next.js 14 App Router AI planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,45 @@
-# AI Planner
+# AI Planner (Next.js 14)
 
-Scaffolded with Next.js (App Router), TypeScript, Tailwind CSS, shadcn/ui setup, and Framer Motion.
+Production-ready App Router project using TypeScript and Tailwind CSS.
 
-## Getting Started
+## Stack
+
+- Next.js 14 App Router
+- Server Components by default
+- Server Actions for write operations
+- Tailwind CSS
+- Supabase REST API for persistence
+
+## Project structure
+
+- `app/dashboard` dashboard route
+- `app/calendar` calendar route
+- `app/posts` posts route
+- `app/posts/[id]` post detail route
+- `app/api/ai` AI API route
+- `components` reusable UI components
+- `lib` domain logic + validation
+- `supabase` typed schema + SQL
+- `ai` AI provider integration
+- `types` shared TypeScript contracts
+
+## Required environment variables
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+OPENAI_API_KEY=
+```
+
+## Database setup
+
+Run the SQL in `supabase/schema.sql` in your Supabase project.
+
+## Commands
 
 ```bash
 npm install
 npm run dev
+npm run lint
+npm run build
 ```
-
-Open [http://localhost:3000](http://localhost:3000).

--- a/ai/planner.ts
+++ b/ai/planner.ts
@@ -1,0 +1,37 @@
+import type { AIPlanRequest, AIPlanResponse } from "@/types";
+
+const openAiUrl = "https://api.openai.com/v1/responses";
+
+export async function generateAIPlan(input: AIPlanRequest): Promise<AIPlanResponse> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured.");
+  }
+
+  const response = await fetch(openAiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4.1-mini",
+      input: `Create a concise daily execution plan for: ${input.prompt}`,
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`AI request failed with status ${response.status}`);
+  }
+
+  const json = (await response.json()) as {
+    output_text?: string;
+  };
+
+  if (!json.output_text) {
+    throw new Error("AI response did not contain output_text.");
+  }
+
+  return { plan: json.output_text };
+}

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { generateAIPlan } from "@/ai/planner";
+import type { AIPlanRequest } from "@/types";
+
+export async function POST(request: Request) {
+  const payload = (await request.json()) as Partial<AIPlanRequest>;
+
+  if (!payload.prompt || typeof payload.prompt !== "string") {
+    return NextResponse.json({ error: "Invalid prompt." }, { status: 400 });
+  }
+
+  try {
+    const response = await generateAIPlan({ prompt: payload.prompt.trim() });
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown AI processing error.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,39 @@
+import { getUpcomingEvents } from "@/lib/dashboard";
+import { formatDateTime } from "@/lib/date";
+
+export default async function CalendarPage() {
+  const events = await getUpcomingEvents();
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-semibold">Calendar</h1>
+        <p className="text-slate-600">Your confirmed schedule for this week.</p>
+      </header>
+      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50 text-left text-slate-600">
+            <tr>
+              <th className="px-4 py-3 font-medium">Event</th>
+              <th className="px-4 py-3 font-medium">Time</th>
+              <th className="px-4 py-3 font-medium">Location</th>
+              <th className="px-4 py-3 font-medium">Notes</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 bg-white">
+            {events.map((event) => (
+              <tr key={event.id}>
+                <td className="px-4 py-3 font-medium">{event.title}</td>
+                <td className="px-4 py-3 text-slate-600">
+                  {formatDateTime(event.startsAt)} - {formatDateTime(event.endsAt)}
+                </td>
+                <td className="px-4 py-3 text-slate-600">{event.location}</td>
+                <td className="px-4 py-3 text-slate-500">{event.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,38 @@
+import { getDashboardMetrics, getUpcomingEvents } from "@/lib/dashboard";
+import { formatDateTime } from "@/lib/date";
+
+export default async function DashboardPage() {
+  const [metrics, events] = await Promise.all([getDashboardMetrics(), getUpcomingEvents()]);
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold">Dashboard</h1>
+        <p className="text-slate-600">Track priorities and team momentum.</p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        {metrics.map((metric) => (
+          <article key={metric.id} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+            <p className="text-sm text-slate-500">{metric.label}</p>
+            <p className="mt-2 text-2xl font-semibold">{metric.value}</p>
+            <p className="mt-1 text-xs text-emerald-700">{metric.delta}</p>
+          </article>
+        ))}
+      </div>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold">Upcoming events</h2>
+        <ul className="mt-4 space-y-3">
+          {events.map((event) => (
+            <li key={event.id} className="rounded-md border border-slate-100 p-3">
+              <p className="font-medium">{event.title}</p>
+              <p className="text-sm text-slate-600">{formatDateTime(event.startsAt)} - {formatDateTime(event.endsAt)}</p>
+              <p className="text-sm text-slate-500">{event.location}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </section>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,32 +1,24 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter } from "next/font/google";
+
+import { AppShell } from "@/components/app-shell";
 
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "AI Planner",
-  description: "Next.js + Tailwind + shadcn/ui + framer-motion starter",
+  description: "Production-ready Next.js 14 planning workspace",
 };
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+      <body className={inter.className}>
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,5 @@
-import { Hero } from "@/components/hero";
+import { redirect } from "next/navigation";
 
-export default function Home() {
-  return (
-    <main className="min-h-screen p-6 sm:p-12">
-      <Hero />
-    </main>
-  );
+export default function HomePage() {
+  redirect("/dashboard");
 }

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from "next/navigation";
+
+import { updatePostAction } from "@/app/posts/actions";
+import { getPostById } from "@/lib/posts";
+
+interface PostPageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default async function PostDetailPage({ params }: PostPageProps) {
+  const post = await getPostById(params.id);
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-semibold">Edit post</h1>
+        <p className="text-slate-600">Update content and publish status.</p>
+      </header>
+      <form action={updatePostAction} className="grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <input type="hidden" name="id" value={post.id} />
+        <label className="grid gap-1">
+          <span className="text-sm font-medium">Title</span>
+          <input
+            type="text"
+            name="title"
+            defaultValue={post.title}
+            required
+            maxLength={120}
+            className="rounded-md border border-slate-300 px-3 py-2"
+          />
+        </label>
+        <label className="grid gap-1">
+          <span className="text-sm font-medium">Body</span>
+          <textarea
+            name="body"
+            rows={10}
+            defaultValue={post.body}
+            required
+            className="rounded-md border border-slate-300 px-3 py-2"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" name="published" defaultChecked={post.published} className="size-4" />
+          <span className="text-sm">Published</span>
+        </label>
+        <button type="submit" className="w-fit rounded-md bg-slate-900 px-4 py-2 text-white">
+          Update post
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/app/posts/actions.ts
+++ b/app/posts/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { createPost, deletePost, updatePost } from "@/lib/posts";
+import { parseCreatePostInput, parseUpdatePostInput } from "@/lib/validators";
+
+export async function createPostAction(formData: FormData): Promise<void> {
+  const input = parseCreatePostInput(formData);
+  await createPost(input);
+  revalidatePath("/posts");
+}
+
+export async function deletePostAction(formData: FormData): Promise<void> {
+  const id = formData.get("id");
+  if (typeof id !== "string" || !id) {
+    throw new Error("Invalid post id.");
+  }
+
+  await deletePost(id);
+  revalidatePath("/posts");
+}
+
+export async function updatePostAction(formData: FormData): Promise<void> {
+  const input = parseUpdatePostInput(formData);
+  await updatePost(input);
+  revalidatePath("/posts");
+  revalidatePath(`/posts/${input.id}`);
+  redirect(`/posts/${input.id}`);
+}

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+import { createPostAction, deletePostAction } from "@/app/posts/actions";
+import { listPosts } from "@/lib/posts";
+import { formatDateTime } from "@/lib/date";
+
+export default async function PostsPage() {
+  const posts = await listPosts();
+
+  return (
+    <section className="space-y-8">
+      <header>
+        <h1 className="text-3xl font-semibold">Posts</h1>
+        <p className="text-slate-600">Create and manage planning updates using server actions.</p>
+      </header>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Create post</h2>
+        <form action={createPostAction} className="mt-4 grid gap-3">
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Title</span>
+            <input
+              type="text"
+              name="title"
+              required
+              maxLength={120}
+              className="rounded-md border border-slate-300 px-3 py-2"
+            />
+          </label>
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Body</span>
+            <textarea name="body" required rows={4} className="rounded-md border border-slate-300 px-3 py-2" />
+          </label>
+          <button type="submit" className="w-fit rounded-md bg-slate-900 px-4 py-2 text-white">
+            Save post
+          </button>
+        </form>
+      </section>
+
+      <section className="space-y-3">
+        {posts.map((post) => (
+          <article key={post.id} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <Link href={`/posts/${post.id}`} className="text-lg font-semibold hover:underline">
+                  {post.title}
+                </Link>
+                <p className="text-sm text-slate-500">
+                  Updated {formatDateTime(post.updated_at)} · {post.published ? "Published" : "Draft"}
+                </p>
+              </div>
+              <form action={deletePostAction}>
+                <input type="hidden" name="id" value={post.id} />
+                <button type="submit" className="rounded-md border border-red-300 px-3 py-1 text-sm text-red-700">
+                  Delete
+                </button>
+              </form>
+            </div>
+            <p className="mt-3 whitespace-pre-wrap text-slate-700">{post.body}</p>
+          </article>
+        ))}
+      </section>
+    </section>
+  );
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+const nav = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/calendar", label: "Calendar" },
+  { href: "/posts", label: "Posts" },
+];
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <Link href="/dashboard" className="text-lg font-semibold">
+            AI Planner
+          </Link>
+          <nav className="flex gap-4 text-sm">
+            {nav.map((item) => (
+              <Link key={item.href} href={item.href} className="rounded px-2 py-1 hover:bg-slate-100">
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>
+    </div>
+  );
+}

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -1,0 +1,30 @@
+import type { CalendarEvent, DashboardMetric } from "@/types";
+
+export async function getDashboardMetrics(): Promise<DashboardMetric[]> {
+  return [
+    { id: "focus-hours", label: "Focus Hours", value: "26h", delta: "+12%" },
+    { id: "tasks-completed", label: "Tasks Completed", value: "34", delta: "+6" },
+    { id: "active-projects", label: "Active Projects", value: "5", delta: "Stable" },
+  ];
+}
+
+export async function getUpcomingEvents(): Promise<CalendarEvent[]> {
+  return [
+    {
+      id: "ev-1",
+      title: "Product design review",
+      startsAt: "2026-02-18T10:00:00.000Z",
+      endsAt: "2026-02-18T11:00:00.000Z",
+      location: "Zoom",
+      notes: "Review the Q2 planning board.",
+    },
+    {
+      id: "ev-2",
+      title: "Engineering stand-up",
+      startsAt: "2026-02-19T08:30:00.000Z",
+      endsAt: "2026-02-19T09:00:00.000Z",
+      location: "Huddle Room A",
+      notes: "Share blockers and release timeline.",
+    },
+  ];
+}

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,6 @@
+export function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,39 @@
+import { cache } from "react";
+
+import {
+  deletePostById,
+  insertPost,
+  selectPostById,
+  selectPosts,
+  updatePostById,
+} from "@/supabase/client";
+import type { CreatePostInput, Post, UpdatePostInput } from "@/types";
+
+export const listPosts = cache(async (): Promise<Post[]> => {
+  return selectPosts();
+});
+
+export async function getPostById(id: string): Promise<Post | null> {
+  return selectPostById(id);
+}
+
+export async function createPost(input: CreatePostInput): Promise<void> {
+  await insertPost({
+    title: input.title,
+    body: input.body,
+    published: false,
+  });
+}
+
+export async function updatePost(input: UpdatePostInput): Promise<void> {
+  await updatePostById(input.id, {
+    title: input.title,
+    body: input.body,
+    published: input.published,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export async function deletePost(id: string): Promise<void> {
+  await deletePostById(id);
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,49 @@
+import type { CreatePostInput, UpdatePostInput } from "@/types";
+
+function readString(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  if (typeof value !== "string") {
+    throw new Error(`Missing field: ${key}`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`Field cannot be empty: ${key}`);
+  }
+
+  return normalized;
+}
+
+export function parseCreatePostInput(formData: FormData): CreatePostInput {
+  const title = readString(formData, "title");
+  const body = readString(formData, "body");
+
+  if (title.length > 120) {
+    throw new Error("Title must be 120 characters or fewer.");
+  }
+
+  return { title, body };
+}
+
+export function parseUpdatePostInput(formData: FormData): UpdatePostInput {
+  const id = readString(formData, "id");
+  const title = readString(formData, "title");
+  const body = readString(formData, "body");
+  const published = formData.get("published") === "on";
+
+  if (title.length > 120) {
+    throw new Error("Title must be 120 characters or fewer.");
+  }
+
+  return { id, title, body, published };
+}
+
+export function parsePrompt(formData: FormData): string {
+  const prompt = readString(formData, "prompt");
+
+  if (prompt.length > 1000) {
+    throw new Error("Prompt must be 1000 characters or fewer.");
+  }
+
+  return prompt;
+}

--- a/package.json
+++ b/package.json
@@ -11,21 +11,19 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.4.7",
-    "lucide-react": "^0.511.0",
-    "next": "15.3.3",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
+    "next": "14.2.25",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.3.3",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.25",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   }

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -1,0 +1,93 @@
+import type { Database } from "@/supabase/database.types";
+
+type PostRow = Database["public"]["Tables"]["posts"]["Row"];
+type PostInsert = Database["public"]["Tables"]["posts"]["Insert"];
+type PostUpdate = Database["public"]["Tables"]["posts"]["Update"];
+
+interface SupabaseResponse<T> {
+  data: T;
+  error: null;
+}
+
+interface SupabaseErrorResponse {
+  error: {
+    message: string;
+  };
+}
+
+function getSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.");
+  }
+
+  return { url, serviceRoleKey };
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const { url, serviceRoleKey } = getSupabaseEnv();
+
+  const response = await fetch(`${url}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      Prefer: "return=representation",
+      ...init?.headers,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as SupabaseErrorResponse | null;
+    throw new Error(body?.error?.message ?? `Supabase request failed (${response.status}).`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function selectPosts(): Promise<PostRow[]> {
+  const query = "posts?select=id,title,body,created_at,updated_at,published&order=created_at.desc";
+  return request<PostRow[]>(query, { method: "GET" });
+}
+
+export async function selectPostById(id: string): Promise<PostRow | null> {
+  const query = `posts?select=id,title,body,created_at,updated_at,published&id=eq.${id}&limit=1`;
+  const rows = await request<PostRow[]>(query, { method: "GET" });
+  return rows[0] ?? null;
+}
+
+export async function insertPost(post: PostInsert): Promise<void> {
+  await request<SupabaseResponse<PostRow[]>>("posts", {
+    method: "POST",
+    body: JSON.stringify(post),
+  });
+}
+
+export async function updatePostById(id: string, update: PostUpdate): Promise<void> {
+  const query = `posts?id=eq.${id}`;
+  await request<SupabaseResponse<PostRow[]>>(query, {
+    method: "PATCH",
+    body: JSON.stringify(update),
+  });
+}
+
+export async function deletePostById(id: string): Promise<void> {
+  const { url, serviceRoleKey } = getSupabaseEnv();
+
+  const response = await fetch(`${url}/rest/v1/posts?id=eq.${id}`, {
+    method: "DELETE",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to delete post (${response.status}).`);
+  }
+}

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -1,0 +1,36 @@
+export interface Database {
+  public: {
+    Tables: {
+      posts: {
+        Row: {
+          id: string;
+          title: string;
+          body: string;
+          created_at: string;
+          updated_at: string;
+          published: boolean;
+        };
+        Insert: {
+          id?: string;
+          title: string;
+          body: string;
+          created_at?: string;
+          updated_at?: string;
+          published?: boolean;
+        };
+        Update: {
+          id?: string;
+          title?: string;
+          body?: string;
+          created_at?: string;
+          updated_at?: string;
+          published?: boolean;
+        };
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,24 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.posts (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  body text not null,
+  published boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists set_posts_updated_at on public.posts;
+create trigger set_posts_updated_at
+before update on public.posts
+for each row
+execute function public.set_updated_at();

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,46 @@
+export type ID = string;
+
+export interface DashboardMetric {
+  id: ID;
+  label: string;
+  value: string;
+  delta: string;
+}
+
+export interface CalendarEvent {
+  id: ID;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  location: string;
+  notes: string;
+}
+
+export interface Post {
+  id: ID;
+  title: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+  published: boolean;
+}
+
+export interface CreatePostInput {
+  title: string;
+  body: string;
+}
+
+export interface UpdatePostInput {
+  id: ID;
+  title: string;
+  body: string;
+  published: boolean;
+}
+
+export interface AIPlanRequest {
+  prompt: string;
+}
+
+export interface AIPlanResponse {
+  plan: string;
+}


### PR DESCRIPTION
### Motivation
- Provide a scalable, production-ready Next.js 14 App Router scaffold using TypeScript and Tailwind with server components as the default and server actions for mutations.
- Include a clean folder layout and strong typing to support posts, dashboard, calendar, AI planning, and Supabase persistence.

### Description
- Upgraded runtime targets and dependencies to Next.js 14 / React 18 and adjusted `package.json` accordingly and added Tailwind-friendly layout and global styles.
- Added a shared `AppShell` and `app/layout.tsx` that renders server components by default and redirects `/` to `/dashboard` via `app/page.tsx`.
- Implemented typed routes and domain utilities: `app/dashboard`, `app/calendar`, `app/posts`, `app/posts/[id]`, `lib/dashboard.ts`, and `lib/date.ts` for server-rendered UI and data formatting.
- Built full server-action flows for posts (`app/posts/actions.ts`) with validation in `lib/validators.ts`, a typed Supabase REST client in `supabase/client.ts`, `supabase/database.types.ts`, and SQL schema in `supabase/schema.sql` for the `posts` table.
- Added an AI integration `ai/planner.ts` and an API route `app/api/ai/route.ts` that accepts a typed `AIPlanRequest` and returns `AIPlanResponse`; added shared types in `types/index.ts` and documented usage in `README.md`.

### Testing
- Attempted `npm install`, but dependency install failed due to the environment's npm registry policy returning `403 Forbidden`, so binary-required validations could not run.
- Attempted `npm run lint`, but it failed because the `next` binary is unavailable without installed dependencies, so linting could not complete.
- Attempted a Playwright screenshot against `http://127.0.0.1:3000`, but the app server was not running because dependencies were not installed, so runtime UI validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d43fcdb08332a5d617d65bf2c977)