### PR TITLE
Implement typed authenticated post CRUD flow

### DIFF
--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -20,35 +20,75 @@ export default async function PostDetailPage({ params }: PostPageProps) {
     <section className="space-y-6">
       <header>
         <h1 className="text-3xl font-semibold">Edit post</h1>
-        <p className="text-slate-600">Update content and publish status.</p>
+        <p className="text-slate-600">Update caption, schedule, and publish status.</p>
       </header>
       <form action={updatePostAction} className="grid gap-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <input type="hidden" name="id" value={post.id} />
         <label className="grid gap-1">
-          <span className="text-sm font-medium">Title</span>
+          <span className="text-sm font-medium">Platform</span>
+          <select name="platform" defaultValue={post.platform} required className="rounded-md border border-slate-300 px-3 py-2">
+            <option value="instagram">Instagram</option>
+            <option value="linkedin">LinkedIn</option>
+            <option value="twitter">Twitter</option>
+          </select>
+        </label>
+        <label className="grid gap-1">
+          <span className="text-sm font-medium">Title (optional)</span>
           <input
             type="text"
             name="title"
             defaultValue={post.title}
-            required
             maxLength={120}
             className="rounded-md border border-slate-300 px-3 py-2"
           />
         </label>
         <label className="grid gap-1">
-          <span className="text-sm font-medium">Body</span>
+          <span className="text-sm font-medium">Caption</span>
           <textarea
-            name="body"
+            name="caption"
             rows={10}
-            defaultValue={post.body}
+            defaultValue={post.caption}
             required
             className="rounded-md border border-slate-300 px-3 py-2"
           />
         </label>
-        <label className="flex items-center gap-2">
-          <input type="checkbox" name="published" defaultChecked={post.published} className="size-4" />
-          <span className="text-sm">Published</span>
+        <label className="grid gap-1">
+          <span className="text-sm font-medium">Image URL (optional)</span>
+          <input
+            type="url"
+            name="image_url"
+            defaultValue={post.image_url}
+            className="rounded-md border border-slate-300 px-3 py-2"
+          />
         </label>
+        <label className="grid gap-1">
+          <span className="text-sm font-medium">Status</span>
+          <select name="status" defaultValue={post.status} required className="rounded-md border border-slate-300 px-3 py-2">
+            <option value="draft">Draft</option>
+            <option value="planned">Planned</option>
+            <option value="posted">Posted</option>
+          </select>
+        </label>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Scheduled date (optional)</span>
+            <input
+              type="date"
+              name="scheduled_date"
+              defaultValue={post.scheduled_date}
+              className="rounded-md border border-slate-300 px-3 py-2"
+            />
+          </label>
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Scheduled time (optional)</span>
+            <input
+              type="time"
+              name="scheduled_time"
+              defaultValue={post.scheduled_time}
+              className="rounded-md border border-slate-300 px-3 py-2"
+            />
+          </label>
+        </div>
         <button type="submit" className="w-fit rounded-md bg-slate-900 px-4 py-2 text-white">
           Update post
         </button>

--- a/app/posts/actions.ts
+++ b/app/posts/actions.ts
@@ -6,9 +6,22 @@ import { redirect } from "next/navigation";
 import { createPost, deletePost, updatePost } from "@/lib/posts";
 import { parseCreatePostInput, parseUpdatePostInput } from "@/lib/validators";
 
+function toActionErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unexpected server error while processing post action.";
+}
+
 export async function createPostAction(formData: FormData): Promise<void> {
-  const input = parseCreatePostInput(formData);
-  await createPost(input);
+  try {
+    const input = parseCreatePostInput(formData);
+    await createPost(input);
+  } catch (error) {
+    throw new Error(toActionErrorMessage(error));
+  }
+
   revalidatePath("/posts");
 }
 
@@ -18,13 +31,24 @@ export async function deletePostAction(formData: FormData): Promise<void> {
     throw new Error("Invalid post id.");
   }
 
-  await deletePost(id);
+  try {
+    await deletePost(id);
+  } catch (error) {
+    throw new Error(toActionErrorMessage(error));
+  }
+
   revalidatePath("/posts");
 }
 
 export async function updatePostAction(formData: FormData): Promise<void> {
   const input = parseUpdatePostInput(formData);
-  await updatePost(input);
+
+  try {
+    await updatePost(input);
+  } catch (error) {
+    throw new Error(toActionErrorMessage(error));
+  }
+
   revalidatePath("/posts");
   revalidatePath(`/posts/${input.id}`);
   redirect(`/posts/${input.id}`);

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,36 +1,60 @@
 import Link from "next/link";
 
 import { createPostAction, deletePostAction } from "@/app/posts/actions";
-import { listPosts } from "@/lib/posts";
 import { formatDateTime } from "@/lib/date";
+import { listPostsForAuthenticatedUser } from "@/lib/posts";
 
 export default async function PostsPage() {
-  const posts = await listPosts();
+  const posts = await listPostsForAuthenticatedUser();
 
   return (
     <section className="space-y-8">
       <header>
         <h1 className="text-3xl font-semibold">Posts</h1>
-        <p className="text-slate-600">Create and manage planning updates using server actions.</p>
+        <p className="text-slate-600">Create and manage social posts with authenticated server actions.</p>
       </header>
 
       <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <h2 className="text-lg font-semibold">Create post</h2>
         <form action={createPostAction} className="mt-4 grid gap-3">
           <label className="grid gap-1">
-            <span className="text-sm font-medium">Title</span>
-            <input
-              type="text"
-              name="title"
-              required
-              maxLength={120}
-              className="rounded-md border border-slate-300 px-3 py-2"
-            />
+            <span className="text-sm font-medium">Platform</span>
+            <select name="platform" required className="rounded-md border border-slate-300 px-3 py-2">
+              <option value="instagram">Instagram</option>
+              <option value="linkedin">LinkedIn</option>
+              <option value="twitter">Twitter</option>
+            </select>
           </label>
           <label className="grid gap-1">
-            <span className="text-sm font-medium">Body</span>
-            <textarea name="body" required rows={4} className="rounded-md border border-slate-300 px-3 py-2" />
+            <span className="text-sm font-medium">Title (optional)</span>
+            <input type="text" name="title" maxLength={120} className="rounded-md border border-slate-300 px-3 py-2" />
           </label>
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Caption</span>
+            <textarea name="caption" required rows={4} className="rounded-md border border-slate-300 px-3 py-2" />
+          </label>
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Image URL (optional)</span>
+            <input type="url" name="image_url" className="rounded-md border border-slate-300 px-3 py-2" />
+          </label>
+          <label className="grid gap-1">
+            <span className="text-sm font-medium">Status</span>
+            <select name="status" required className="rounded-md border border-slate-300 px-3 py-2">
+              <option value="draft">Draft</option>
+              <option value="planned">Planned</option>
+              <option value="posted">Posted</option>
+            </select>
+          </label>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <label className="grid gap-1">
+              <span className="text-sm font-medium">Scheduled date (optional)</span>
+              <input type="date" name="scheduled_date" className="rounded-md border border-slate-300 px-3 py-2" />
+            </label>
+            <label className="grid gap-1">
+              <span className="text-sm font-medium">Scheduled time (optional)</span>
+              <input type="time" name="scheduled_time" className="rounded-md border border-slate-300 px-3 py-2" />
+            </label>
+          </div>
           <button type="submit" className="w-fit rounded-md bg-slate-900 px-4 py-2 text-white">
             Save post
           </button>
@@ -43,10 +67,10 @@ export default async function PostsPage() {
             <div className="flex items-start justify-between gap-3">
               <div>
                 <Link href={`/posts/${post.id}`} className="text-lg font-semibold hover:underline">
-                  {post.title}
+                  {post.title || "Untitled post"}
                 </Link>
                 <p className="text-sm text-slate-500">
-                  Updated {formatDateTime(post.updated_at)} · {post.published ? "Published" : "Draft"}
+                  {post.platform} · {post.status} · Updated {formatDateTime(post.updated_at)}
                 </p>
               </div>
               <form action={deletePostAction}>
@@ -56,7 +80,7 @@ export default async function PostsPage() {
                 </button>
               </form>
             </div>
-            <p className="mt-3 whitespace-pre-wrap text-slate-700">{post.body}</p>
+            <p className="mt-3 whitespace-pre-wrap text-slate-700">{post.caption}</p>
           </article>
         ))}
       </section>

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,39 +1,79 @@
 import { cache } from "react";
 
 import {
-  deletePostById,
+  deletePostByIdForUser,
   insertPost,
-  selectPostById,
-  selectPosts,
-  updatePostById,
+  requireAuthenticatedUserId,
+  selectPostByIdForUser,
+  selectPostsByUserId,
+  updatePostByIdForUser,
 } from "@/supabase/client";
 import type { CreatePostInput, Post, UpdatePostInput } from "@/types";
 
-export const listPosts = cache(async (): Promise<Post[]> => {
-  return selectPosts();
+function toPost(row: Awaited<ReturnType<typeof selectPostsByUserId>>[number]): Post {
+  return {
+    ...row,
+    title: row.title ?? undefined,
+    image_url: row.image_url ?? undefined,
+    scheduled_date: row.scheduled_date ?? undefined,
+    scheduled_time: row.scheduled_time ?? undefined,
+  };
+}
+
+export const listPostsForAuthenticatedUser = cache(async (): Promise<Post[]> => {
+  const userId = await requireAuthenticatedUserId();
+  const rows = await selectPostsByUserId(userId);
+  return rows.map(toPost);
 });
 
 export async function getPostById(id: string): Promise<Post | null> {
-  return selectPostById(id);
+  const userId = await requireAuthenticatedUserId();
+  const row = await selectPostByIdForUser(id, userId);
+  return row ? toPost(row) : null;
 }
 
 export async function createPost(input: CreatePostInput): Promise<void> {
+  const userId = await requireAuthenticatedUserId();
+
   await insertPost({
-    title: input.title,
-    body: input.body,
-    published: false,
+    user_id: userId,
+    platform: input.platform,
+    title: input.title ?? null,
+    caption: input.caption,
+    image_url: input.image_url ?? null,
+    status: input.status,
+    scheduled_date: input.scheduled_date ?? null,
+    scheduled_time: input.scheduled_time ?? null,
   });
 }
 
 export async function updatePost(input: UpdatePostInput): Promise<void> {
-  await updatePostById(input.id, {
-    title: input.title,
-    body: input.body,
-    published: input.published,
+  const userId = await requireAuthenticatedUserId();
+  const existingPost = await selectPostByIdForUser(input.id, userId);
+
+  if (!existingPost) {
+    throw new Error("Post not found or access denied.");
+  }
+
+  await updatePostByIdForUser(input.id, userId, {
+    platform: input.platform,
+    title: input.title ?? null,
+    caption: input.caption,
+    image_url: input.image_url ?? null,
+    status: input.status,
+    scheduled_date: input.scheduled_date ?? null,
+    scheduled_time: input.scheduled_time ?? null,
     updated_at: new Date().toISOString(),
   });
 }
 
 export async function deletePost(id: string): Promise<void> {
-  await deletePostById(id);
+  const userId = await requireAuthenticatedUserId();
+  const existingPost = await selectPostByIdForUser(id, userId);
+
+  if (!existingPost) {
+    throw new Error("Post not found or access denied.");
+  }
+
+  await deletePostByIdForUser(id, userId);
 }

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,6 +1,9 @@
-import type { CreatePostInput, UpdatePostInput } from "@/types";
+import type { CreatePostInput, PostPlatform, PostStatus, UpdatePostInput } from "@/types";
 
-function readString(formData: FormData, key: string): string {
+const allowedPlatforms: readonly PostPlatform[] = ["instagram", "linkedin", "twitter"];
+const allowedStatuses: readonly PostStatus[] = ["draft", "planned", "posted"];
+
+function readRequiredString(formData: FormData, key: string): string {
   const value = formData.get(key);
   if (typeof value !== "string") {
     throw new Error(`Missing field: ${key}`);
@@ -14,32 +17,76 @@ function readString(formData: FormData, key: string): string {
   return normalized;
 }
 
-export function parseCreatePostInput(formData: FormData): CreatePostInput {
-  const title = readString(formData, "title");
-  const body = readString(formData, "body");
+function readOptionalString(formData: FormData, key: string): string | undefined {
+  const value = formData.get(key);
+  if (typeof value !== "string") {
+    return undefined;
+  }
 
-  if (title.length > 120) {
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function parsePlatform(value: string): PostPlatform {
+  if (allowedPlatforms.includes(value as PostPlatform)) {
+    return value as PostPlatform;
+  }
+
+  throw new Error("Invalid platform.");
+}
+
+function parseStatus(value: string): PostStatus {
+  if (allowedStatuses.includes(value as PostStatus)) {
+    return value as PostStatus;
+  }
+
+  throw new Error("Invalid status.");
+}
+
+function buildPostInput(formData: FormData): Omit<CreatePostInput, never> {
+  const platform = parsePlatform(readRequiredString(formData, "platform"));
+  const caption = readRequiredString(formData, "caption");
+  const status = parseStatus(readRequiredString(formData, "status"));
+  const title = readOptionalString(formData, "title");
+  const image_url = readOptionalString(formData, "image_url");
+  const scheduled_date = readOptionalString(formData, "scheduled_date");
+  const scheduled_time = readOptionalString(formData, "scheduled_time");
+
+  if (caption.length > 2000) {
+    throw new Error("Caption must be 2000 characters or fewer.");
+  }
+
+  if (title && title.length > 120) {
     throw new Error("Title must be 120 characters or fewer.");
   }
 
-  return { title, body };
+  return {
+    platform,
+    title,
+    caption,
+    image_url,
+    status,
+    scheduled_date,
+    scheduled_time,
+  };
+}
+
+export function parseCreatePostInput(formData: FormData): CreatePostInput {
+  return buildPostInput(formData);
 }
 
 export function parseUpdatePostInput(formData: FormData): UpdatePostInput {
-  const id = readString(formData, "id");
-  const title = readString(formData, "title");
-  const body = readString(formData, "body");
-  const published = formData.get("published") === "on";
+  const id = readRequiredString(formData, "id");
+  const input = buildPostInput(formData);
 
-  if (title.length > 120) {
-    throw new Error("Title must be 120 characters or fewer.");
-  }
-
-  return { id, title, body, published };
+  return {
+    id,
+    ...input,
+  };
 }
 
 export function parsePrompt(formData: FormData): string {
-  const prompt = readString(formData, "prompt");
+  const prompt = readRequiredString(formData, "prompt");
 
   if (prompt.length > 1000) {
     throw new Error("Prompt must be 1000 characters or fewer.");

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -1,18 +1,20 @@
+import { cookies, headers } from "next/headers";
+
 import type { Database } from "@/supabase/database.types";
 
 type PostRow = Database["public"]["Tables"]["posts"]["Row"];
 type PostInsert = Database["public"]["Tables"]["posts"]["Insert"];
 type PostUpdate = Database["public"]["Tables"]["posts"]["Update"];
 
-interface SupabaseResponse<T> {
-  data: T;
-  error: null;
+interface SupabaseAuthUser {
+  id: string;
 }
 
 interface SupabaseErrorResponse {
-  error: {
-    message: string;
+  error?: {
+    message?: string;
   };
+  message?: string;
 }
 
 function getSupabaseEnv() {
@@ -24,6 +26,10 @@ function getSupabaseEnv() {
   }
 
   return { url, serviceRoleKey };
+}
+
+function parseErrorMessage(body: SupabaseErrorResponse | null, status: number): string {
+  return body?.error?.message ?? body?.message ?? `Supabase request failed (${status}).`;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -43,51 +49,107 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as SupabaseErrorResponse | null;
-    throw new Error(body?.error?.message ?? `Supabase request failed (${response.status}).`);
+    throw new Error(parseErrorMessage(body, response.status));
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
   }
 
   return (await response.json()) as T;
 }
 
-export async function selectPosts(): Promise<PostRow[]> {
-  const query = "posts?select=id,title,body,created_at,updated_at,published&order=created_at.desc";
-  return request<PostRow[]>(query, { method: "GET" });
+function getAccessTokenFromRequest(): string | null {
+  const authHeader = headers().get("authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7).trim();
+  }
+
+  const cookieStore = cookies();
+  const tokenCookieNames = [
+    "sb-access-token",
+    "supabase-access-token",
+    "access_token",
+  ];
+
+  for (const cookieName of tokenCookieNames) {
+    const token = cookieStore.get(cookieName)?.value;
+    if (token) {
+      return token;
+    }
+  }
+
+  return null;
 }
 
-export async function selectPostById(id: string): Promise<PostRow | null> {
-  const query = `posts?select=id,title,body,created_at,updated_at,published&id=eq.${id}&limit=1`;
-  const rows = await request<PostRow[]>(query, { method: "GET" });
-  return rows[0] ?? null;
-}
+export async function requireAuthenticatedUserId(): Promise<string> {
+  const { url } = getSupabaseEnv();
+  const accessToken = getAccessTokenFromRequest();
 
-export async function insertPost(post: PostInsert): Promise<void> {
-  await request<SupabaseResponse<PostRow[]>>("posts", {
-    method: "POST",
-    body: JSON.stringify(post),
-  });
-}
+  if (!accessToken) {
+    throw new Error("Unauthorized: missing access token.");
+  }
 
-export async function updatePostById(id: string, update: PostUpdate): Promise<void> {
-  const query = `posts?id=eq.${id}`;
-  await request<SupabaseResponse<PostRow[]>>(query, {
-    method: "PATCH",
-    body: JSON.stringify(update),
-  });
-}
-
-export async function deletePostById(id: string): Promise<void> {
-  const { url, serviceRoleKey } = getSupabaseEnv();
-
-  const response = await fetch(`${url}/rest/v1/posts?id=eq.${id}`, {
-    method: "DELETE",
+  const response = await fetch(`${url}/auth/v1/user`, {
+    method: "GET",
     headers: {
-      apikey: serviceRoleKey,
-      Authorization: `Bearer ${serviceRoleKey}`,
+      Authorization: `Bearer ${accessToken}`,
     },
     cache: "no-store",
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to delete post (${response.status}).`);
+    throw new Error("Unauthorized: invalid access token.");
   }
+
+  const user = (await response.json().catch(() => null)) as SupabaseAuthUser | null;
+  if (!user?.id) {
+    throw new Error("Unauthorized: user not found.");
+  }
+
+  return user.id;
+}
+
+export async function selectPostsByUserId(userId: string): Promise<PostRow[]> {
+  const query = [
+    "posts?select=id,user_id,platform,title,caption,image_url,status,scheduled_date,scheduled_time,created_at,updated_at",
+    `user_id=eq.${userId}`,
+    "order=created_at.desc",
+  ].join("&");
+
+  return request<PostRow[]>(query, { method: "GET" });
+}
+
+export async function selectPostByIdForUser(id: string, userId: string): Promise<PostRow | null> {
+  const query = [
+    "posts?select=id,user_id,platform,title,caption,image_url,status,scheduled_date,scheduled_time,created_at,updated_at",
+    `id=eq.${id}`,
+    `user_id=eq.${userId}`,
+    "limit=1",
+  ].join("&");
+
+  const rows = await request<PostRow[]>(query, { method: "GET" });
+  return rows[0] ?? null;
+}
+
+export async function insertPost(post: PostInsert): Promise<void> {
+  await request<PostRow[]>("posts", {
+    method: "POST",
+    body: JSON.stringify(post),
+  });
+}
+
+export async function updatePostByIdForUser(id: string, userId: string, update: PostUpdate): Promise<void> {
+  const query = `posts?id=eq.${id}&user_id=eq.${userId}`;
+  await request<PostRow[]>(query, {
+    method: "PATCH",
+    body: JSON.stringify(update),
+  });
+}
+
+export async function deletePostByIdForUser(id: string, userId: string): Promise<void> {
+  const query = `posts?id=eq.${id}&user_id=eq.${userId}`;
+  await request<void>(query, {
+    method: "DELETE",
+  });
 }

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -4,27 +4,42 @@ export interface Database {
       posts: {
         Row: {
           id: string;
-          title: string;
-          body: string;
+          user_id: string;
+          platform: "instagram" | "linkedin" | "twitter";
+          title: string | null;
+          caption: string;
+          image_url: string | null;
+          status: "draft" | "planned" | "posted";
+          scheduled_date: string | null;
+          scheduled_time: string | null;
           created_at: string;
           updated_at: string;
-          published: boolean;
         };
         Insert: {
           id?: string;
-          title: string;
-          body: string;
+          user_id: string;
+          platform: "instagram" | "linkedin" | "twitter";
+          title?: string | null;
+          caption: string;
+          image_url?: string | null;
+          status?: "draft" | "planned" | "posted";
+          scheduled_date?: string | null;
+          scheduled_time?: string | null;
           created_at?: string;
           updated_at?: string;
-          published?: boolean;
         };
         Update: {
           id?: string;
-          title?: string;
-          body?: string;
+          user_id?: string;
+          platform?: "instagram" | "linkedin" | "twitter";
+          title?: string | null;
+          caption?: string;
+          image_url?: string | null;
+          status?: "draft" | "planned" | "posted";
+          scheduled_date?: string | null;
+          scheduled_time?: string | null;
           created_at?: string;
           updated_at?: string;
-          published?: boolean;
         };
       };
     };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,10 +1,18 @@
 create extension if not exists "pgcrypto";
 
+create type if not exists public.post_platform as enum ('instagram', 'linkedin', 'twitter');
+create type if not exists public.post_status as enum ('draft', 'planned', 'posted');
+
 create table if not exists public.posts (
   id uuid primary key default gen_random_uuid(),
-  title text not null,
-  body text not null,
-  published boolean not null default false,
+  user_id uuid not null,
+  platform public.post_platform not null,
+  title text,
+  caption text not null,
+  image_url text,
+  status public.post_status not null default 'draft',
+  scheduled_date date,
+  scheduled_time time,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,25 +16,43 @@ export interface CalendarEvent {
   notes: string;
 }
 
+export type PostPlatform = "instagram" | "linkedin" | "twitter";
+
+export type PostStatus = "draft" | "planned" | "posted";
+
 export interface Post {
   id: ID;
-  title: string;
-  body: string;
+  user_id: ID;
+  platform: PostPlatform;
+  title?: string;
+  caption: string;
+  image_url?: string;
+  status: PostStatus;
+  scheduled_date?: string;
+  scheduled_time?: string;
   created_at: string;
   updated_at: string;
-  published: boolean;
 }
 
 export interface CreatePostInput {
-  title: string;
-  body: string;
+  platform: PostPlatform;
+  title?: string;
+  caption: string;
+  image_url?: string;
+  status: PostStatus;
+  scheduled_date?: string;
+  scheduled_time?: string;
 }
 
 export interface UpdatePostInput {
   id: ID;
-  title: string;
-  body: string;
-  published: boolean;
+  platform: PostPlatform;
+  title?: string;
+  caption: string;
+  image_url?: string;
+  status: PostStatus;
+  scheduled_date?: string;
+  scheduled_time?: string;
 }
 
 export interface AIPlanRequest {


### PR DESCRIPTION
### Motivation

- Replace the simple blog-style post model with a typed social-post schema (platform, caption, status, optional title/image/schedule, and ownership) to support multi-platform scheduling and stronger type safety. 
- Enforce server-side authentication and ownership checks so all reads/writes/deletes are scoped to the authenticated user and no client-side direct DB mutations occur. 
- Improve validation and error handling for server actions so invalid input or unauthorized access surface consistent server errors.

### Description

- Introduced typed post contracts in `types/index.ts` with `PostPlatform` / `PostStatus`, `Post`, `CreatePostInput`, and `UpdatePostInput` matching the requested schema. 
- Updated DB schema and typings in `supabase/schema.sql` and `supabase/database.types.ts`, and added server-side Supabase helpers in `supabase/client.ts` to validate access tokens, parse errors, and scope REST queries by `user_id`. 
- Implemented authenticated domain logic in `lib/posts.ts` and strong parsing/validation in `lib/validators.ts`, including null→optional mappings and limits for `title`/`caption`. 
- Reworked server actions in `app/posts/actions.ts` and UI pages `app/posts/page.tsx` and `app/posts/[id]/page.tsx` to use the new fields (`platform`, `caption`, `status`, scheduling fields, `image_url`) and to perform all mutations via server actions with consistent error translation.

### Testing

- Ran `npm run lint` which failed in this environment due to Next.js configuration incompatibility (`next.config.ts` unsupported); lint errors are environmental and not caused by the new code. 
- Ran `npx tsc --noEmit` which failed due to an existing missing dependency (`framer-motion`) in the project; TypeScript checks otherwise reflect the new typed contracts. 
- Attempted `npm run dev` which failed for the same `next.config.ts` issue, preventing live UI verification in this runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d7328e748332ba0dc754b0639206)