### PR TITLE
Add server-side AI service with caption rewrite, shortening, auth, and usage logging

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -1,18 +1,51 @@
 import { NextResponse } from "next/server";
 
-import { generateAIPlan } from "@/ai/planner";
-import type { AIPlanRequest } from "@/types";
+import { requireAuthenticatedUser } from "@/lib/auth";
+import { rewriteCaption, shortenText } from "@/lib/ai/service";
+import { insertAILog } from "@/supabase/client";
+
+type AIAction = "rewrite_caption" | "shorten_text";
+
+interface AIRequestBody {
+  action?: AIAction;
+  text?: string;
+}
 
 export async function POST(request: Request) {
-  const payload = (await request.json()) as Partial<AIPlanRequest>;
+  const payload = (await request.json()) as AIRequestBody;
 
-  if (!payload.prompt || typeof payload.prompt !== "string") {
-    return NextResponse.json({ error: "Invalid prompt." }, { status: 400 });
+  if (!payload.action || !payload.text || typeof payload.text !== "string") {
+    return NextResponse.json({ error: "Invalid payload." }, { status: 400 });
+  }
+
+  let userId: string;
+
+  try {
+    const user = await requireAuthenticatedUser(request);
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const inputText = payload.text.trim();
+  if (!inputText) {
+    return NextResponse.json({ error: "Text is required." }, { status: 400 });
   }
 
   try {
-    const response = await generateAIPlan({ prompt: payload.prompt.trim() });
-    return NextResponse.json(response, { status: 200 });
+    const outputText =
+      payload.action === "rewrite_caption"
+        ? await rewriteCaption(inputText)
+        : await shortenText(inputText);
+
+    await insertAILog({
+      user_id: userId,
+      action: payload.action,
+      input_text: inputText,
+      output_text: outputText,
+    });
+
+    return NextResponse.json({ result: outputText }, { status: 200 });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown AI processing error.";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/lib/ai/service.ts
+++ b/lib/ai/service.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+const openAiUrl = "https://api.openai.com/v1/responses";
+
+async function generateText(instruction: string, userInput: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured.");
+  }
+
+  const response = await fetch(openAiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4.1-mini",
+      input: [
+        {
+          role: "system",
+          content: instruction,
+        },
+        {
+          role: "user",
+          content: userInput,
+        },
+      ],
+    }),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`AI request failed with status ${response.status}`);
+  }
+
+  const json = (await response.json()) as {
+    output_text?: string;
+  };
+
+  if (!json.output_text) {
+    throw new Error("AI response did not contain output_text.");
+  }
+
+  return json.output_text.trim();
+}
+
+export async function rewriteCaption(caption: string): Promise<string> {
+  return generateText(
+    "Rewrite the caption to sound clear, engaging, and natural. Keep it close in meaning. Return only the rewritten caption.",
+    caption,
+  );
+}
+
+export async function shortenText(text: string): Promise<string> {
+  return generateText(
+    "Shorten the user text while preserving core meaning and tone. Return only the shortened text.",
+    text,
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+export interface AuthenticatedUser {
+  id: string;
+  email?: string;
+}
+
+function getSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.");
+  }
+
+  return { url, serviceRoleKey };
+}
+
+export async function requireAuthenticatedUser(request: Request): Promise<AuthenticatedUser> {
+  const authHeader = request.headers.get("authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : "";
+
+  if (!token) {
+    throw new Error("Unauthorized");
+  }
+
+  const { url, serviceRoleKey } = getSupabaseEnv();
+  const response = await fetch(`${url}/auth/v1/user`, {
+    method: "GET",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${token}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Unauthorized");
+  }
+
+  const data = (await response.json()) as AuthenticatedUser;
+  if (!data.id) {
+    throw new Error("Unauthorized");
+  }
+
+  return data;
+}

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -3,6 +3,7 @@ import type { Database } from "@/supabase/database.types";
 type PostRow = Database["public"]["Tables"]["posts"]["Row"];
 type PostInsert = Database["public"]["Tables"]["posts"]["Insert"];
 type PostUpdate = Database["public"]["Tables"]["posts"]["Update"];
+type AILogInsert = Database["public"]["Tables"]["ai_logs"]["Insert"];
 
 interface SupabaseResponse<T> {
   data: T;
@@ -90,4 +91,11 @@ export async function deletePostById(id: string): Promise<void> {
   if (!response.ok) {
     throw new Error(`Failed to delete post (${response.status}).`);
   }
+}
+
+export async function insertAILog(log: AILogInsert): Promise<void> {
+  await request<SupabaseResponse<AILogInsert[]>>("ai_logs", {
+    method: "POST",
+    body: JSON.stringify(log),
+  });
 }

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -1,6 +1,32 @@
 export interface Database {
   public: {
     Tables: {
+      ai_logs: {
+        Row: {
+          id: string;
+          user_id: string;
+          action: string;
+          input_text: string;
+          output_text: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          action: string;
+          input_text: string;
+          output_text: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          action?: string;
+          input_text?: string;
+          output_text?: string;
+          created_at?: string;
+        };
+      };
       posts: {
         Row: {
           id: string;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -22,3 +22,13 @@ create trigger set_posts_updated_at
 before update on public.posts
 for each row
 execute function public.set_updated_at();
+
+
+create table if not exists public.ai_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  action text not null,
+  input_text text not null,
+  output_text text not null,
+  created_at timestamptz not null default now()
+);


### PR DESCRIPTION
### Motivation

- Centralize AI execution on the server to keep API keys and model calls out of the browser. 
- Provide reusable text-processing utilities for caption rewriting and shortening to be used by multiple endpoints. 
- Ensure only authenticated users may run AI requests and persist usage in the database for auditing and analytics.

### Description

- Add a server-only AI service at `lib/ai/service.ts` that implements a common `generateText` helper plus `rewriteCaption` and `shortenText` exported functions which call the OpenAI Responses API. 
- Add an authentication helper `lib/auth.ts` with `requireAuthenticatedUser` that validates a bearer token against Supabase Auth. 
- Replace the AI endpoint at `app/api/ai/route.ts` with an action-based route that accepts `rewrite_caption` and `shorten_text`, enforces authentication, calls the server AI service, and returns the generated text. 
- Add `ai_logs` persistence by extending `supabase/schema.sql` and `supabase/database.types.ts`, and expose `insertAILog` in `supabase/client.ts` which the API route uses to record `user_id`, `action`, `input_text`, `output_text`, and `created_at`.

### Testing

- Ran `npm run lint` which failed in this environment due to the local Next CLI rejecting `next.config.ts` (error: "Configuring Next.js via 'next.config.ts' is not supported."), so no lint pass was completed. 
- No additional automated tests were present or run in this environment; all changes were validated by local file updates and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d739ffe0833281bb88b5eb4f3837)