### PR TITLE
Add lightweight monthly calendar component for posts

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,39 +1,22 @@
-import { getUpcomingEvents } from "@/lib/dashboard";
-import { formatDateTime } from "@/lib/date";
+import { MonthlyCalendar } from "@/components/monthly-calendar";
+import { listPosts } from "@/lib/posts";
 
 export default async function CalendarPage() {
-  const events = await getUpcomingEvents();
+  const posts = await listPosts();
+
+  const scheduledPosts = posts.map((post) => ({
+    id: post.id,
+    title: post.title,
+    scheduled_date: post.created_at.slice(0, 10),
+  }));
 
   return (
     <section className="space-y-6">
       <header>
         <h1 className="text-3xl font-semibold">Calendar</h1>
-        <p className="text-slate-600">Your confirmed schedule for this week.</p>
+        <p className="text-slate-600">View posts by date and quickly filter the day&apos;s schedule.</p>
       </header>
-      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-        <table className="min-w-full divide-y divide-slate-200 text-sm">
-          <thead className="bg-slate-50 text-left text-slate-600">
-            <tr>
-              <th className="px-4 py-3 font-medium">Event</th>
-              <th className="px-4 py-3 font-medium">Time</th>
-              <th className="px-4 py-3 font-medium">Location</th>
-              <th className="px-4 py-3 font-medium">Notes</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100 bg-white">
-            {events.map((event) => (
-              <tr key={event.id}>
-                <td className="px-4 py-3 font-medium">{event.title}</td>
-                <td className="px-4 py-3 text-slate-600">
-                  {formatDateTime(event.startsAt)} - {formatDateTime(event.endsAt)}
-                </td>
-                <td className="px-4 py-3 text-slate-600">{event.location}</td>
-                <td className="px-4 py-3 text-slate-500">{event.notes}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <MonthlyCalendar posts={scheduledPosts} />
     </section>
   );
 }

--- a/components/monthly-calendar.tsx
+++ b/components/monthly-calendar.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type CalendarPost = {
+  id: string;
+  title: string;
+  scheduled_date: string;
+};
+
+interface MonthlyCalendarProps {
+  posts: CalendarPost[];
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function toReadableDate(dateKey: string): string {
+  return new Date(`${dateKey}T00:00:00`).toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function MonthlyCalendar({ posts }: MonthlyCalendarProps) {
+  const today = new Date();
+  const [visibleMonth, setVisibleMonth] = useState(new Date(today.getFullYear(), today.getMonth(), 1));
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
+
+  const postsByDate = useMemo(() => {
+    const grouped = new Map<string, CalendarPost[]>();
+
+    posts.forEach((post) => {
+      const dateKey = post.scheduled_date;
+      const existing = grouped.get(dateKey) ?? [];
+      existing.push(post);
+      grouped.set(dateKey, existing);
+    });
+
+    return grouped;
+  }, [posts]);
+
+  const days = useMemo(() => {
+    const year = visibleMonth.getFullYear();
+    const month = visibleMonth.getMonth();
+
+    const firstOfMonth = new Date(year, month, 1);
+    const dayOffset = firstOfMonth.getDay();
+    const gridStart = new Date(year, month, 1 - dayOffset);
+
+    return Array.from({ length: 42 }, (_, index) => {
+      const current = new Date(gridStart);
+      current.setDate(gridStart.getDate() + index);
+      return current;
+    });
+  }, [visibleMonth]);
+
+  const filteredPosts = useMemo(() => {
+    if (!selectedDateKey) {
+      return [];
+    }
+
+    return postsByDate.get(selectedDateKey) ?? [];
+  }, [postsByDate, selectedDateKey]);
+
+  const monthLabel = visibleMonth.toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="mb-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => setVisibleMonth(new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() - 1, 1))}
+            className="rounded-md border border-slate-300 px-3 py-1 text-sm"
+          >
+            Previous
+          </button>
+          <h2 className="text-lg font-semibold">{monthLabel}</h2>
+          <button
+            type="button"
+            onClick={() => setVisibleMonth(new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 1))}
+            className="rounded-md border border-slate-300 px-3 py-1 text-sm"
+          >
+            Next
+          </button>
+        </div>
+
+        <div className="grid grid-cols-7 gap-2 text-center text-xs font-medium uppercase text-slate-500">
+          {[
+            "Sun",
+            "Mon",
+            "Tue",
+            "Wed",
+            "Thu",
+            "Fri",
+            "Sat",
+          ].map((day) => (
+            <span key={day}>{day}</span>
+          ))}
+        </div>
+
+        <div className="mt-2 grid grid-cols-7 gap-2">
+          {days.map((date) => {
+            const dateKey = toDateKey(date);
+            const count = postsByDate.get(dateKey)?.length ?? 0;
+            const isCurrentMonth = date.getMonth() === visibleMonth.getMonth();
+            const isSelected = selectedDateKey === dateKey;
+
+            const dayClassName = isSelected
+              ? "min-h-20 rounded-md border border-slate-900 bg-slate-900 p-2 text-left text-white"
+              : `min-h-20 rounded-md border border-slate-200 p-2 text-left ${
+                  isCurrentMonth ? "bg-white" : "bg-slate-50 text-slate-400"
+                }`;
+
+            return (
+              <button
+                key={dateKey}
+                type="button"
+                onClick={() => setSelectedDateKey(dateKey)}
+                className={dayClassName}
+              >
+                <p className="text-sm font-medium">{date.getDate()}</p>
+                {count > 0 && (
+                  <span
+                    className={`mt-2 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                      isSelected ? "bg-white text-slate-900" : "bg-slate-900 text-white"
+                    }`}
+                  >
+                    {count} post{count > 1 ? "s" : ""}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="text-lg font-semibold">
+          {selectedDateKey ? `Posts for ${toReadableDate(selectedDateKey)}` : "Select a day to view posts"}
+        </h3>
+        {selectedDateKey && (
+          <ul className="mt-3 space-y-2">
+            {filteredPosts.length === 0 ? (
+              <li className="text-sm text-slate-500">No posts scheduled for this date.</li>
+            ) : (
+              filteredPosts.map((post) => (
+                <li key={post.id} className="rounded-md border border-slate-200 p-3 text-sm">
+                  {post.title}
+                </li>
+              ))
+            )}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, maintainable monthly calendar view so posts can be explored by date without adding a heavy calendar dependency.
- Accept posts as props and let the UI group and filter them by `scheduled_date` to keep calendar logic decoupled from data-fetching.

### Description
- Added a client-side `MonthlyCalendar` component at `components/monthly-calendar.tsx` that accepts `posts` (id, title, scheduled_date) and groups them by date using a `Map` and `useMemo` for lightweight, memoized logic.
- The calendar renders a 7x6 grid for the visible month, shows per-day post count badges, and updates a `selectedDateKey` on day click to filter posts for that date.
- Replaced the old events table on `/calendar` with the new component in `app/calendar/page.tsx`, and populated `scheduled_date` from `post.created_at.slice(0, 10)` when passing props.
- Styling is minimal Tailwind classes and the component keeps all logic local (no external calendar libraries), with an explicit day-classname computation for clear selected/current-month state.

### Testing
- Ran `npm run lint`, which failed due to the repository having `next.config.ts` (Next.js in this environment requires `.js`/`.mjs`).
- Ran `npx tsc --noEmit`, which failed due to a pre-existing missing dependency (`framer-motion`) referenced by `components/hero.tsx` in this repo.
- Attempted `npm run dev` for visual verification, which also failed for the same `next.config.ts` configuration issue, so live UI checks were not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d744108083328036db42364f68bb)